### PR TITLE
Update TODO and add notes for Rust migration

### DIFF
--- a/rust-migration/notes.txt
+++ b/rust-migration/notes.txt
@@ -1,0 +1,10 @@
+# Internal notes and questions for the Rust migration
+
+* **nusb evaluation**: The driver skeleton currently relies on the `nusb` crate. I need to verify whether it provides stable support across Linux, Windows, and macOS. If features are missing we may need to patch upstream or fall back to `rusb`.
+* **DSP porting**: The C code has several DSP routines such as the IQ balancer. I'm uncertain how best to translate these to idiomatic Rust while maintaining performance. Investigate using `num-complex` and `futures` for streaming.
+* **Threading model**: The original driver uses pthreads. We haven't decided whether to use `std::thread` or an async runtime (`tokio`). Need to prototype both approaches.
+* **FFI design**: Current interface exposes raw pointers for device handles. Consider a higher-level safe wrapper for internal use while keeping the C ABI stable.
+* **Testing strategy**: Only a single open/close test exists. We will need to design integration tests that exercise streaming and error paths, possibly using property-based testing.
+* **Verification tools**: Unsure whether `Prusti` or `Creusot` will be practical for the DSP pieces. Evaluate once more Rust code is present.
+* **Build system integration**: Eventually the Rust library should produce CMake config files to replace the existing `libairspyhf.pc`. Need to research `cmake-rs` or `pkg-config` helpers.
+* **Next steps**: flesh out the device enumeration and streaming functions in Rust, continue documenting the C modules for reference, and set up CI.

--- a/rust-migration/todo.txt
+++ b/rust-migration/todo.txt
@@ -1,69 +1,49 @@
 1. **Analyze current driver architecture**
+   - **Status**: Initial pass completed.
    - Read existing C/C++ sources under `libairspyhf/` and `tools/`.
-   - Document each module's responsibilities, APIs, and dependencies.
-   - Record any external dependencies (e.g., libusb, pthreads).
-   - Note that the repository does not include the full source for these
-     dependencies, which complicates verification efforts and necessitates
-     replacing them with Rust-native alternatives.
+   - Documented major modules and identified heavy use of `libusb` and pthreads.
+   - External dependencies noted: `libusb`, `pthread`, Windows-specific USB code.
+   - Still need a deeper look at DSP components and platform differences.
 
 2. **Define Rust project structure**
-   - Create a new Cargo workspace for the library and tools.
-   - Provide a `libairspyhf-rs` crate mirroring the C API via `extern "C"`.
-   - Provide CLI utilities as separate crates within the workspace.
+   - **Status**: In progress.
+   - Created a Cargo workspace `rust-migration` containing the `libairspyhf` crate.
+   - Exposes a C ABI via `extern "C"` functions (open/close so far).
+   - CLI utilities and examples are not yet ported.
 
 3. **Port functionality module by module**
-   - Translate each C source file to a safe Rust module.
-   - Use explicit types and enums to avoid undefined behaviour.
-   - For FFI, expose C-compatible interfaces with `#[no_mangle]` and
-     `extern "C"` functions.
-   - Deny the use of `unsafe` unless absolutely necessary and document each
-     occurrence.
-   - Replace pthread usage with safe Rust equivalents such as `std::thread`,
-     `crossbeam`, or asynchronous runtimes (`tokio`, `async-std`).
+   - **Status**: Started.
+   - Implemented device open/close using `nusb` with basic unit test.
+   - Remaining C functions for streaming, configuration and DSP are unported.
+   - Plan to replace pthreads with `std::thread` or an async runtime.
 
 4. **Documentation and style**
-   - Write comprehensive `///` documentation for every public item.
-   - Keep naming conventions close to the original C functions to aid
-     understanding for C++ developers.
-   - Include extensive inline comments explaining design decisions.
+   - **Status**: Minimal docs in place.
+   - Need comprehensive `///` documentation for public items and inline comments.
 
 5. **Testing and validation**
-   - Reproduce the original driver's unit tests if any; otherwise design new
-     tests to cover all APIs.
-   - Use `cargo test` for unit and integration tests.
-   - Apply property-based testing (`proptest` or `quickcheck`) for robustness.
+   - **Status**: Skeleton test for open/close.
+   - Must design integration tests that mirror the original driver's behaviour.
+   - Property-based tests are planned but not implemented.
 
 6. **Formal verification efforts**
-   - Run `cargo clippy` and `cargo fmt` with `#![deny(warnings)]`.
-   - Integrate static analyzers (e.g., `cargo audit`, `cargo udeps`).
-   - Explore tools like `Prusti` or `Creusot` to formally verify critical
-     algorithms.
-   - Ensure all memory safety and concurrency aspects are proven or thoroughly
-     tested.
+   - **Status**: Not started.
+   - Set up `cargo clippy`, `cargo fmt` with warnings denied.
+   - Investigate `Prusti` or `Creusot` once more code is available.
 
 7. **Cross-platform build configuration**
-   - Provide USB access using a pure Rust solution. Prefer the `nusb` crate
-     for higher reliability, falling back to `rusb` or `yusb` only if necessary.
-   - Verify builds on Linux (GNU and MUSL), Windows, and macOS using CI.
-   - Ensure `nusb` supports required features on all platforms and contribute
-     upstream patches if gaps are found.
-   - Document API differences between `libusb` and `nusb` and update the driver
-     design accordingly.
-   - Offer CMake or pkg-config files so that C++ applications can link against
-     the Rust library seamlessly.
+   - **Status**: Pending.
+   - Ensure `nusb` works on Linux, Windows, and macOS.
+   - Provide CMake/pkg-config files for C++ consumers.
 
 8. **Continuous Integration setup**
-   - Configure GitHub Actions to build and test on all supported platforms.
-   - Run formatting, linting, and test suites on each pull request.
-   - Optionally produce release artifacts (static and shared libraries, tools).
+   - **Status**: Pending.
+   - Add GitHub Actions to build and test across platforms and run linting.
 
 9. **Migration guide**
-   - Write detailed documentation describing differences between the original
-     driver and the Rust implementation.
-   - Provide example code snippets for C++ developers demonstrating how to use
-     the new library.
+   - **Status**: Pending.
+   - Document API differences and provide examples for C++ developers.
 
 10. **Final review and publish**
-    - Perform a code audit ensuring every module is documented and tested.
-    - Tag a release once parity with the original driver is achieved and
-      verification criteria are met.
+    - **Status**: Pending.
+    - Audit the code, ensure tests pass on all targets, and prepare release tags.


### PR DESCRIPTION
## Summary
- refine todo list with current progress and pending tasks
- add notes file tracking open questions
- adjust safety and clippy issues in Rust skeleton

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684097ab2360832d9c5608de43014f79