### PR TITLE
Continue Rust migration with enumeration features

### DIFF
--- a/rust-migration/libairspyhf/src/lib.rs
+++ b/rust-migration/libairspyhf/src/lib.rs
@@ -6,6 +6,18 @@
 
 use std::io::{self, ErrorKind};
 use std::sync::Mutex;
+const USB_VID: u16 = 0x03EB;
+const USB_PID: u16 = 0x800C;
+
+pub const AIRSPYHF_VER_MAJOR: u32 = 1;
+pub const AIRSPYHF_VER_MINOR: u32 = 8;
+pub const AIRSPYHF_VER_REVISION: u32 = 0;
+#[repr(C)]
+pub struct AirspyhfLibVersion {
+    pub major_version: u32,
+    pub minor_version: u32,
+    pub revision: u32,
+}
 
 use nusb::{self, Device, MaybeFuture};
 
@@ -25,13 +37,52 @@ impl AirspyHfDevice {
         let di = nusb::list_devices()
             .wait()
             .map_err(io::Error::other)?
-            .find(|d| d.vendor_id() == 0x03EB && d.product_id() == 0x800C)
+            .find(|d| d.vendor_id() == USB_VID && d.product_id() == USB_PID)
             .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "AirspyHF not found"))?;
         let device = di.open().wait().map_err(io::Error::other)?;
         Ok(AirspyHfDevice {
             handle: Mutex::new(device),
             _private: (),
         })
+    }
+}
+
+impl AirspyHfDevice {
+    pub fn open_by_serial(serial: u64) -> Result<Self, io::Error> {
+        let devices = nusb::list_devices().wait().map_err(io::Error::other)?;
+        for di in devices {
+            if di.vendor_id() == USB_VID && di.product_id() == USB_PID {
+                if let Some(sn) = di.serial_number() {
+                    if let Some(hex) = sn.strip_prefix("AIRSPYHF SN:") {
+                        if u64::from_str_radix(hex, 16).unwrap_or(0) == serial {
+                            let dev = di.open().wait().map_err(io::Error::other)?;
+                            return Ok(AirspyHfDevice {
+                                handle: Mutex::new(dev),
+                                _private: (),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        Err(io::Error::new(ErrorKind::NotFound, "AirspyHF not found"))
+    }
+
+    pub fn list_serials() -> Result<Vec<u64>, io::Error> {
+        let devices = nusb::list_devices().wait().map_err(io::Error::other)?;
+        let mut out = Vec::new();
+        for di in devices {
+            if di.vendor_id() == USB_VID && di.product_id() == USB_PID {
+                if let Some(sn) = di.serial_number() {
+                    if let Some(hex) = sn.strip_prefix("AIRSPYHF SN:") {
+                        if let Ok(val) = u64::from_str_radix(hex, 16) {
+                            out.push(val);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(out)
     }
 }
 
@@ -100,4 +151,40 @@ mod tests {
             }
         }
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn airspyhf_open_sn(out: *mut AirspyhfDeviceHandle, serial: u64) -> i32 {
+    let dev = match AirspyHfDevice::open_by_serial(serial) {
+        Ok(d) => Box::into_raw(Box::new(d)),
+        Err(_) => return AirspyhfError::Error as i32,
+    };
+    if !out.is_null() {
+        *out = dev;
+    }
+    AirspyhfError::Success as i32
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn airspyhf_list_devices(serials: *mut u64, count: i32) -> i32 {
+    match AirspyHfDevice::list_serials() {
+        Ok(list) => {
+            if !serials.is_null() && count > 0 {
+                let len = list.len().min(count as usize);
+                std::ptr::copy_nonoverlapping(list.as_ptr(), serials, len);
+            }
+            list.len() as i32
+        }
+        Err(_) => AirspyhfError::Error as i32,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn airspyhf_lib_version(ver: *mut AirspyhfLibVersion) {
+    if ver.is_null() {
+        return;
+    }
+    (*ver).major_version = AIRSPYHF_VER_MAJOR;
+    (*ver).minor_version = AIRSPYHF_VER_MINOR;
+    (*ver).revision = AIRSPYHF_VER_REVISION;
 }

--- a/rust-migration/notes.txt
+++ b/rust-migration/notes.txt
@@ -8,3 +8,4 @@
 * **Verification tools**: Unsure whether `Prusti` or `Creusot` will be practical for the DSP pieces. Evaluate once more Rust code is present.
 * **Build system integration**: Eventually the Rust library should produce CMake config files to replace the existing `libairspyhf.pc`. Need to research `cmake-rs` or `pkg-config` helpers.
 * **Next steps**: flesh out the device enumeration and streaming functions in Rust, continue documenting the C modules for reference, and set up CI.
+\n* Device enumeration now implemented via `airspyhf_list_devices` and `airspyhf_open_sn`. Need to verify serial string parsing on Windows.

--- a/rust-migration/todo.txt
+++ b/rust-migration/todo.txt
@@ -8,12 +8,13 @@
 2. **Define Rust project structure**
    - **Status**: In progress.
    - Created a Cargo workspace `rust-migration` containing the `libairspyhf` crate.
-   - Exposes a C ABI via `extern "C"` functions (open/close so far).
+   - Exposes a C ABI via `extern "C"` functions (open/close, list devices, open by serial).
    - CLI utilities and examples are not yet ported.
 
 3. **Port functionality module by module**
    - **Status**: Started.
    - Implemented device open/close using `nusb` with basic unit test.
+   - Added `airspyhf_list_devices` and `airspyhf_open_sn` for enumeration.
    - Remaining C functions for streaming, configuration and DSP are unported.
    - Plan to replace pthreads with `std::thread` or an async runtime.
 
@@ -23,6 +24,7 @@
 
 5. **Testing and validation**
    - **Status**: Skeleton test for open/close.
+   - Need unit tests for `airspyhf_list_devices` and `airspyhf_open_sn`.
    - Must design integration tests that mirror the original driver's behaviour.
    - Property-based tests are planned but not implemented.
 


### PR DESCRIPTION
## Summary
- add USB and version constants
- add `AirspyhfLibVersion` structure
- implement `open_by_serial` and `list_serials` helpers
- expose FFI for listing devices, opening by serial and querying library version
- update notes and todo documentation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684099031674832d878b53db2f22291e