### PR TITLE
Continue rust driver migration

### DIFF
--- a/rust-migration/notes.txt
+++ b/rust-migration/notes.txt
@@ -13,3 +13,6 @@
 * Introduced a minimal `IqBalancer` stub applying simple phase/amplitude correction.
 * Added simple setter/getter functions for frequency, samplerate and calibration fields.
 * Streaming start/stop currently just toggles flags without spawning threads.
+* Implemented stubs for attenuation control, bias tee configuration, user output
+  handling and board information retrieval. These merely store values in the
+  device struct for now; USB commands remain unimplemented.

--- a/rust-migration/todo.txt
+++ b/rust-migration/todo.txt
@@ -20,7 +20,9 @@
    - Implemented basic setters/getters for samplerate, frequency and
      calibration values.
    - Stubbed streaming start/stop and flash configuration routines.
-   - Remaining streaming threads and DSP routines are still unported.
+   - Added placeholder implementations for attenuation control, bias tee,
+     user output pins and board info APIs.
+   - Remaining streaming threads and full DSP routines are still unported.
    - Plan to replace pthreads with `std::thread` or an async runtime.
 
 4. **Documentation and style**


### PR DESCRIPTION
## Summary
- expand device struct with configuration fields
- add default attenuation step constants and lists
- implement configuration stubs (attenuation, bias tee, AGC, etc.)
- document progress in notes and todo lists

## Testing
- `cargo test`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6840a4f068e8832db99d57dedc554d2a