### PR TITLE
Expand Rust driver features

### DIFF
--- a/rust-migration/notes.txt
+++ b/rust-migration/notes.txt
@@ -12,7 +12,8 @@
 * Basic status helpers (`airspyhf_get_output_size`, `airspyhf_is_low_if`, `airspyhf_is_streaming`) implemented.
 * Introduced a minimal `IqBalancer` stub applying simple phase/amplitude correction.
 * Added simple setter/getter functions for frequency, samplerate and calibration fields.
-* Streaming start/stop currently just toggles flags without spawning threads.
-* Implemented stubs for attenuation control, bias tee configuration, user output
-  handling and board information retrieval. These merely store values in the
-  device struct for now; USB commands remain unimplemented.
+* Streaming start/stop currently only sends the receiver mode control transfer
+  but still lacks real data threads.
+* Implemented USB vendor command helpers and wired them into several setter
+  functions (VCTCXO calibration, frontend options, attenuation, bias tee,
+  AGC/LNA and board info queries).

--- a/rust-migration/todo.txt
+++ b/rust-migration/todo.txt
@@ -19,9 +19,12 @@
      `airspyhf_is_low_if` and placeholder `IqBalancer` bindings.
    - Implemented basic setters/getters for samplerate, frequency and
      calibration values.
-   - Stubbed streaming start/stop and flash configuration routines.
+   - Streaming start/stop now issues the receiver mode control transfer but
+     still lacks worker threads. Flash configuration remains stubbed.
    - Added placeholder implementations for attenuation control, bias tee,
      user output pins and board info APIs.
+   - Implemented USB vendor command helpers for frequency, samplerate,
+     calibration, frontend options and bias tee control.
    - Remaining streaming threads and full DSP routines are still unported.
    - Plan to replace pthreads with `std::thread` or an async runtime.
 


### PR DESCRIPTION
## Summary
- add vendor command helpers for nusb control transfers
- use vendor commands in setter functions
- send receiver mode requests when starting/stopping
- document progress in notes and todo

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840a69cc00c832d89d36e646e569b96