### PR TITLE
Rust migration improvements

### DIFF
--- a/rust-migration/notes.txt
+++ b/rust-migration/notes.txt
@@ -22,3 +22,8 @@
 * Flash configuration write/read implemented via vendor commands.
 * Devices opened now load stored calibration on startup.
 * Added linux-only support for airspyhf_open_fd using nusb::Device::from_fd.
+* Supported samplerates and attenuation steps are now queried from the firmware
+  at device open. Filter gain is retrieved as well so DSP scaling matches the
+  C driver. Frequency tuning now accounts for firmware-provided frequency delta
+  just like the original implementation. Streaming enables the receiver after
+  the worker thread starts.

--- a/rust-migration/todo.txt
+++ b/rust-migration/todo.txt
@@ -27,6 +27,9 @@
      user output pins and board info APIs.
    - Implemented USB vendor command helpers for frequency, samplerate,
      calibration, frontend options and bias tee control.
+   - Firmware queries now fetch supported samplerates, architectures,
+     attenuation steps and filter gain during device open.
+     Frequency tuning mirrors the C implementation including freq_delta.
    - Remaining streaming threads and full DSP routines are still unported.
    - Plan to replace pthreads with `std::thread` or an async runtime.
 


### PR DESCRIPTION
## Summary
- query supported sample rates and attenuation steps from firmware
- retrieve filter gain and frequency delta for tuning
- improve start streaming logic and freq tuning
- document progress in notes and todo

## Testing
- `cargo test -p libairspyhf`

------
https://chatgpt.com/codex/tasks/task_e_6840aea4d264832d837cd38524fd4695