### PR TITLE
Add FFT scaffolding for Rust IQ balancer

### DIFF
--- a/rust-migration/libairspyhf/Cargo.toml
+++ b/rust-migration/libairspyhf/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 nusb = "0.2.0-beta.1"
+num-complex = "0.4"
+rustfft = "6"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary
- scaffold the Rust IQ balancer with FFT window initialization
- add rustfft and num-complex dependencies
- prepare working buffer and FFT instance in the balancer

## Testing
- `cargo check -p libairspyhf`

------
https://chatgpt.com/codex/tasks/task_e_6840b9185e0c832d8044369859080364