### PR TITLE
Fix Windows control transfers

### DIFF
--- a/rust-migration/libairspyhf/src/lib.rs
+++ b/rust-migration/libairspyhf/src/lib.rs
@@ -317,41 +317,92 @@ impl AirspyHfDevice {
 
     fn vendor_out(&self, request: u8, value: u16, index: u16, data: &[u8]) -> io::Result<()> {
         let handle = self.handle.lock().unwrap().clone();
-        handle
-            .control_out(
-                ControlOut {
-                    control_type: ControlType::Vendor,
-                    recipient: Recipient::Device,
-                    request,
-                    value,
-                    index,
-                    data,
-                },
-                Duration::from_millis(CTRL_TIMEOUT_MS),
-            )
-            .wait()
-            .map_err(io::Error::other)
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+        {
+            handle
+                .control_out(
+                    ControlOut {
+                        control_type: ControlType::Vendor,
+                        recipient: Recipient::Device,
+                        request,
+                        value,
+                        index,
+                        data,
+                    },
+                    Duration::from_millis(CTRL_TIMEOUT_MS),
+                )
+                .wait()
+                .map_err(io::Error::other)
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let iface = handle
+                .claim_interface(0)
+                .wait()
+                .map_err(io::Error::other)?;
+            iface
+                .control_out(
+                    ControlOut {
+                        control_type: ControlType::Vendor,
+                        recipient: Recipient::Device,
+                        request,
+                        value,
+                        index,
+                        data,
+                    },
+                    Duration::from_millis(CTRL_TIMEOUT_MS),
+                )
+                .wait()
+                .map_err(io::Error::other)
+        }
     }
 
     fn vendor_in(&self, request: u8, value: u16, index: u16, buf: &mut [u8]) -> io::Result<usize> {
         let handle = self.handle.lock().unwrap().clone();
-        let data = handle
-            .control_in(
-                ControlIn {
-                    control_type: ControlType::Vendor,
-                    recipient: Recipient::Device,
-                    request,
-                    value,
-                    index,
-                    length: buf.len() as u16,
-                },
-                Duration::from_millis(CTRL_TIMEOUT_MS),
-            )
-            .wait()
-            .map_err(io::Error::other)?;
-        let len = std::cmp::min(data.len(), buf.len());
-        buf[..len].copy_from_slice(&data[..len]);
-        Ok(len)
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+        {
+            let data = handle
+                .control_in(
+                    ControlIn {
+                        control_type: ControlType::Vendor,
+                        recipient: Recipient::Device,
+                        request,
+                        value,
+                        index,
+                        length: buf.len() as u16,
+                    },
+                    Duration::from_millis(CTRL_TIMEOUT_MS),
+                )
+                .wait()
+                .map_err(io::Error::other)?;
+            let len = std::cmp::min(data.len(), buf.len());
+            buf[..len].copy_from_slice(&data[..len]);
+            Ok(len)
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let iface = handle
+                .claim_interface(0)
+                .wait()
+                .map_err(io::Error::other)?;
+            let data = iface
+                .control_in(
+                    ControlIn {
+                        control_type: ControlType::Vendor,
+                        recipient: Recipient::Device,
+                        request,
+                        value,
+                        index,
+                        length: buf.len() as u16,
+                    },
+                    Duration::from_millis(CTRL_TIMEOUT_MS),
+                )
+                .wait()
+                .map_err(io::Error::other)?;
+            let len = std::cmp::min(data.len(), buf.len());
+            buf[..len].copy_from_slice(&data[..len]);
+            Ok(len)
+        }
     }
 
     fn read_flash_config(&mut self) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- send vendor control transfers via an interface on Windows

## Testing
- `cargo check --target x86_64-pc-windows-gnu`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840c1162610832d9ca7835f47e26e47