### PR TITLE
Optimize rust release settings

### DIFF
--- a/rust-migration/.cargo/config.toml
+++ b/rust-migration/.cargo/config.toml
@@ -6,6 +6,5 @@ target = "x86_64-unknown-linux-gnu"
 rustflags = [
     "-C", "target-cpu=native",
     "-C", "target-feature=+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx",
-    "-C", "opt-level=3",
-    "-C", "target-feature=+fast-math"
+    "-C", "opt-level=3"
 ]

--- a/rust-migration/Cargo.toml
+++ b/rust-migration/Cargo.toml
@@ -8,3 +8,6 @@ opt-level = 1
 
 [profile.release]
 opt-level = 3
+debug = false
+codegen-units = 1
+lto = "thin"


### PR DESCRIPTION
## Summary
- update rust workspace profile to remove debug info
- use thin LTO with single codegen unit
- drop unsupported `fast-math` compiler flag

## Testing
- `cargo build --release`

------
https://chatgpt.com/codex/tasks/task_e_6840c439d6dc832d8c2f9811972284ba