### PR TITLE
Update IQ balancer docs and add license headers

### DIFF
--- a/rust-migration/libairspyhf/src/iq_balancer.rs
+++ b/rust-migration/libairspyhf/src/iq_balancer.rs
@@ -1,3 +1,20 @@
+/*
+Copyright (c) 2016-2023, Youssef Touil <youssef@airspy.com>
+Copyright (c) 2018, Leif Asbrink <leif@sm5bsz.com>
+Copyright (C) 2024, Joshuah Rainstar <joshuah.rainstar@gmail.com>
+Contributions to this work were provided by OpenAI Codex, an artificial general intelligence.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Airspy HF+ nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 use crate::AirspyhfComplexFloat;
 use num_complex::Complex32;
 use rustfft::{Fft, FftPlanner};
@@ -64,12 +81,10 @@ fn init_library() {
     });
 }
 
-/// Simplified port of the complex IQ balancer used in the C driver.
+/// Port of the complex IQ balancer used in the C++ driver.
 ///
-/// This implementation still omits the heavy FFT based imbalance estimation
-/// but follows the original structure so the remaining pieces can be filled in
-/// incrementally.  The DC removal and phase/amplitude adjustment mirror the
-/// C++ logic.
+/// This implementation performs the full FFT based imbalance estimation
+/// and applies phase and amplitude corrections that mirror the C++ logic.
 #[repr(C)]
 pub struct IqBalancer {
     pub phase: f32,

--- a/rust-migration/libairspyhf/src/lib.rs
+++ b/rust-migration/libairspyhf/src/lib.rs
@@ -1,3 +1,20 @@
+/*
+Copyright (c) 2016-2023, Youssef Touil <youssef@airspy.com>
+Copyright (c) 2018, Leif Asbrink <leif@sm5bsz.com>
+Copyright (C) 2024, Joshuah Rainstar <joshuah.rainstar@gmail.com>
+Contributions to this work were provided by OpenAI Codex, an artificial general intelligence.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Airspy HF+ nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 //! Rust port of the AirspyHF driver.
 //!
 //! This crate is currently a work in progress.  It exposes a C ABI compatible
@@ -336,10 +353,7 @@ impl AirspyHfDevice {
         }
         #[cfg(target_os = "windows")]
         {
-            let iface = handle
-                .claim_interface(0)
-                .wait()
-                .map_err(io::Error::other)?;
+            let iface = handle.claim_interface(0).wait().map_err(io::Error::other)?;
             iface
                 .control_out(
                     ControlOut {
@@ -381,10 +395,7 @@ impl AirspyHfDevice {
         }
         #[cfg(target_os = "windows")]
         {
-            let iface = handle
-                .claim_interface(0)
-                .wait()
-                .map_err(io::Error::other)?;
+            let iface = handle.claim_interface(0).wait().map_err(io::Error::other)?;
             let data = iface
                 .control_in(
                     ControlIn {


### PR DESCRIPTION
## Summary
- add BSD-3 license header to Rust sources
- fix IQ balancer comment to reflect full algorithm

## Testing
- `cargo fmt --manifest-path rust-migration/libairspyhf/Cargo.toml`
- `cargo test --manifest-path rust-migration/libairspyhf/Cargo.toml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6840c860accc832db8ba07b7cb09ff0b