### PR TITLE
Thread safety hardening

### DIFF
--- a/rust-migration/notes.txt
+++ b/rust-migration/notes.txt
@@ -43,3 +43,7 @@
 
 * Cross-platform builds: added example config for Windows
 * Initial exploration of formal verification tools (Prusti, Creusot)
+
+* Thread safety improvements: Atomic stop/streaming flags, parameter mutex, thread id to avoid join deadlocks.
+* convert_samples now locks around IQ balancing and frequency shifting to avoid races.
+* Added sanity tests covering restart and closing while streaming.

--- a/rust-migration/todo.txt
+++ b/rust-migration/todo.txt
@@ -67,3 +67,11 @@
 10. **Final review and publish**
     - **Status**: Pending.
     - Audit the code, ensure tests pass on all targets, and prepare release tags.
+
+11. **Thread-safety hardening**
+   - **Status**: In progress.
+   - Introduced AtomicBool for streaming and stop flags.
+   - Added mutex-based `param_lock` protecting shared fields.
+   - Streaming thread id stored to avoid deadlocks when stopping from callback.
+   - convert_samples locked around IQ balancing and freq shift.
+   - Added restart/close regression tests.


### PR DESCRIPTION
## Summary
- introduce AtomicBool flags and parameter locking
- ensure stream is stopped on close
- guard IQ balancer configuration and samplerate/frequency setters
- document new thread-safety plan in todo/notes
- wrap IQ balancer processing in mutex
- add restart and close-while-streaming tests

## Testing
- `cargo test --manifest-path rust-migration/libairspyhf/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6841a744907c832d92dfb845450c46dc