### PR TITLE
Fix rust driver streaming

### DIFF
--- a/rust-migration/libairspyhf/src/lib.rs
+++ b/rust-migration/libairspyhf/src/lib.rs
@@ -594,10 +594,14 @@ impl AirspyHfDevice {
                 Ok(i) => i,
                 Err(_) => return,
             };
+            if iface.set_alt_setting(1).wait().is_err() {
+                return;
+            }
             let mut ep = match iface.endpoint::<nusb::transfer::Bulk, nusb::transfer::In>(0x81) {
                 Ok(e) => e,
                 Err(_) => return,
             };
+            let _ = ep.clear_halt().wait();
             let buf_len = (SAMPLES_TO_TRANSFER as usize) * 4;
             for _ in 0..RAW_BUFFER_COUNT {
                 let mut b = ep.allocate(buf_len);


### PR DESCRIPTION
## Summary
- ensure interface alt setting and endpoint state are configured before streaming

## Testing
- `cargo fmt --manifest-path rust-migration/libairspyhf/Cargo.toml`
- `cargo check --manifest-path rust-migration/libairspyhf/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6841b8f5c9d0832d9b09b8f8e9327f63